### PR TITLE
Passing a block

### DIFF
--- a/lib/token_master/core.rb
+++ b/lib/token_master/core.rb
@@ -11,8 +11,8 @@ module TokenMaster
           define_method("set_#{tokenable}_token!".to_sym) do
             TokenMaster::Model.set_token!(self, tokenable)
           end
-          define_method("send_#{tokenable}_instructions!".to_sym) do
-            TokenMaster::Model.send_instructions!(self, tokenable, &Proc.new)
+          define_method("send_#{tokenable}_instructions!".to_sym) do |&email|
+            TokenMaster::Model.send_instructions!(self, tokenable, &email)
           end
           define_method("#{tokenable}_status") do
             TokenMaster::Model.status(self, tokenable)

--- a/lib/token_master/model.rb
+++ b/lib/token_master/model.rb
@@ -36,7 +36,7 @@ module TokenMaster
         check_token_set! model, key
         check_instructions_sent! model, key
 
-        Proc.new.call if block_given?
+        yield if block_given?
 
         model.update!(sent_at_col(key) => Time.now)
       end


### PR DESCRIPTION
correct syntax for making a block optional for `send_instructions!` with `define_method`