### PR TITLE
fix dependency issue with how TokenMaster::Model module is added to A…

### DIFF
--- a/lib/token_master/railtie.rb
+++ b/lib/token_master/railtie.rb
@@ -6,11 +6,7 @@ module TokenMaster
 
     initializer 'token_master.active_record' do
       ActiveSupport.on_load :active_record do
-        if Rails::VERSION::MAJOR >= 5
-          ::ApplicationRecord.include(TokenMaster::Model)
-        else
-          ::ActiveRecord::Base.include(TokenMaster::Model)
-        end
+        include TokenMaster::Model
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/LaunchPadLab/token-master/issues/47

Since we're using the `on_load` hook, `self` is actually the ApplicationRecord class (or ActiveRecord::Base for Rails 4), so there is no need to use the class name when including our module. Referencing `ApplicationRecord` was creating a circular dependency, though I'm not sure why.

Here is an article that explains it more: https://simonecarletti.com/blog/2011/04/understanding-ruby-and-rails-lazy-load-hooks/